### PR TITLE
Fix code-block language annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module "api-gateway-lambda-dynamodb" {
 5. Run `terraform apply -var-file="<.tfvars file>` to deploy infrastructure
 
 **Example Deployment Script**
-```js
+```sh
 #!/usr/bin/env bash
 
 if [[ ! -d .terraform ]]; then


### PR DESCRIPTION
If you check https://registry.terraform.io/modules/crisboarna/api-gateway-lambda-dynamodb/aws/1.14.0#deployment, it looks a little odd to see `JAVASCRIPT` in bold over a section of shell script.